### PR TITLE
Fix new user only includes viewer for VBC

### DIFF
--- a/src/UI/Users.php
+++ b/src/UI/Users.php
@@ -153,7 +153,7 @@ final class Users
         }
 
         // For VBC, make sure Roles::VIEWER is included
-        if (array_key_exists('app', $body_params) && $body_params['app'] !== 'VBC') {
+        if (!array_key_exists('app', $body_params) || $body_params['app'] === 'VBC') {
             if (!in_array(Roles::VIEWER, $roles)) {
                 array_push($roles, Roles::VIEWER);
             }


### PR DESCRIPTION
A check in the new user code was the wrong way round, so new users would always have the `VIEWER` role, which is meaningless in an application